### PR TITLE
Fix format of package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     name='ctapipe-extra',
     version=version['__version__'],
     packages=find_packages(),
-    package_data={'ctapipe_resources': '*'},
+    package_data={'ctapipe_resources': ['*']},
 )


### PR DESCRIPTION
The latest version of setuptools does not accept a single string as value in `package_data`, the current release now raises:

```
error in ctapipe-extra setup command: "values of 'package_data' dict" must be a list of strings (got '*')
```

